### PR TITLE
Add "retrowars-latest" to manage new game additions gracefully.

### DIFF
--- a/docs/.well-known/com.serwylo.retrowars-servers.json
+++ b/docs/.well-known/com.serwylo.retrowars-servers.json
@@ -1,4 +1,5 @@
 [
+  {"hostname": "retrowars-latest.serwylo.com", "port": 80},
   {"hostname": "retrowars1.serwylo.com", "port": 80},
   {"hostname": "retrowars2.serwylo.com", "port": 80}
 ]


### PR DESCRIPTION
If we were to setup "retrowars1" to only accept people with the new client, then they will have a poor experience prior to upgrading. They would need to typically wait 10 seconds or so for Heroku to fire up "retrowars2", which is really just a backup in case all else fails.